### PR TITLE
feat(theme,home): mode révision + reprise de session

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,11 +1,11 @@
 import Image from "next/image";
 import Link from "next/link.js";
+import HomeResume from "@/components/HomeResume";
 
 export default function Home() {
   return (
     <main className="min-h-screen bg-[#00264d] flex flex-col items-center justify-center px-4 py-8 space-y-6">
       <h1 className="text-white text-2xl font-bold mb-6">Choisis un thème</h1>
-
       <div className="w-full max-w-xs space-y-4">
         <Link
           href="/theme/interieur"
@@ -40,12 +40,8 @@ export default function Home() {
           PREMIER SECOURS
         </Link>
       </div>
-
-      <input
-        type="text"
-        placeholder="Recherche par mots clé"
-        className="mt-8 w-full max-w-xs p-3 rounded-full text-center text-sm text-gray-800 placeholder-gray-400"
-      />
+      <HomeResume />{" "}
+      {/* <= le bouton “Continuer là où j’en étais” apparaît ici */}
     </main>
   );
 }

--- a/src/app/theme/[slug]/page.js
+++ b/src/app/theme/[slug]/page.js
@@ -1,46 +1,236 @@
+import Link from "next/link";
 import { supabase } from "@/lib/supabaseClient";
+import StudyList from "@/components/StudyList";
+import LastVisitedWriter from "@/components/LastVisitedWriter";
+
 
 export const dynamic = "force-dynamic";
 
 export default async function Page({ params }) {
   const { slug } = await params;
 
+  // 1) Slugs -> libellés
   const themeMap = {
     interieur: { id: 1, label: "Vérifications INTÉRIEUR" },
     exterieur: { id: 2, label: "Vérifications EXTÉRIEUR" },
-    secours: { id: 3, label: "Questions PREMIERS SECOURS" },
     securite: { id: 4, label: "Questions SÉCURITÉ ROUTIÈRE" },
+    secours: { id: 3, label: "Questions PREMIERS SECOURS" },
+  };
+
+  // 2) Palette CENTRALISÉE (reprise de ta home)
+  const THEME_COLORS = {
+    pageBg: "#00264d", // fond général
+    interieur: "#1f4f82", // bleu foncé
+    exterieur: "#207ce5", // bleu clair
+    securite: "#f1b90b", // jaune
+    secours: "#c14d2c", // rouge
   };
 
   const theme = themeMap[slug];
+  if (!theme) return <main className="p-6 text-red-600">Thème inconnu</main>;
 
-  if (!theme) {
-    return <main className="p-6 text-red-600">Thème inconnu</main>;
-  }
+  const color = THEME_COLORS[slug] ?? THEME_COLORS.interieur;
 
-  const { data: fiches, error } = await supabase
+  // 3) Data
+  const { data: fichesRaw, error } = await supabase
     .from("verifications")
     .select("*")
     .eq("themes_id", theme.id);
 
+  const fiches = Array.isArray(fichesRaw) ? fichesRaw : [];
+
   return (
-    <main className="min-h-screen p-6 bg-white text-black">
-      <h1 className="text-2xl font-bold mb-4">{theme.label}</h1>
+    <main
+      className="min-h-screen"
+      style={{ backgroundColor: THEME_COLORS.pageBg }}
+    >
+      <LastVisitedWriter slug={slug} />
 
-      {error && <p className="text-red-500">Erreur : {error.message}</p>}
+      <div className="mx-auto max-w-6xl px-4 py-6 md:py-8">
+        {/* Feuille centrale – on pose la couleur dans une CSS var --c */}
+        <div
+          className="relative isolate rounded-3xl bg-white ring-1 ring-black/5 shadow-lg"
+          style={{ ["--c"]: color }}
+        >
+          {/* Header sticky, offset mobile + menu non coupé */}
+          <div className="sticky z-20 top-2 sm:top-3 md:top-0 overflow-visible rounded-t-3xl border-b border-zinc-200/70 bg-white/95 supports-[backdrop-filter]:bg-white/70 backdrop-blur md:backdrop-blur-none">
+            <div className="px-4 py-3 sm:px-6 sm:py-4 space-y-3">
+              {/* Ligne 1 : retour + titre + compteur coloré */}
+              <div className="flex items-start sm:items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <BackHome />
+                  <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-zinc-900">
+                    {theme.label}
+                  </h1>
+                </div>
 
-      {fiches.length === 0 ? (
-        <p>Aucune fiche trouvée pour ce thème.</p>
-      ) : (
-        <ul className="space-y-4">
-          {fiches.map((fiche) => (
-            <li key={fiche.id} className="bg-gray-100 p-4 rounded shadow">
-              <p className="font-semibold">{fiche.question}</p>
-              <p className="text-sm text-gray-600 mt-2">{fiche.reponse}</p>
-            </li>
-          ))}
-        </ul>
-      )}
+                {/* Chip du compteur = couleur du thème */}
+                <span
+                  className="
+                    shrink-0 inline-flex items-center justify-center rounded-full
+                    px-3 py-1 text-[11px] font-medium whitespace-nowrap min-w-[92px]
+                    text-white
+                    [background:var(--c)]
+                  "
+                >
+                  {fiches.length} élément{fiches.length > 1 ? "s" : ""}
+                </span>
+              </div>
+
+              {/* Ligne 2 : switcher desktop + mobile (coloré) */}
+              <div className="flex items-center justify-between">
+                <ThemeSwitcherDesktop current={slug} colors={THEME_COLORS} />
+                <ThemeSwitcherMobile current={slug} colors={THEME_COLORS} />
+              </div>
+            </div>
+          </div>
+
+          {/* Contenu */}
+          <div className="px-3 pb-6 pt-4 sm:px-6">
+            {error && (
+              <p className="mb-3 text-sm text-red-600">
+                Erreur : {error.message}
+              </p>
+            )}
+
+            {fiches.length === 0 ? (
+              <p className="text-zinc-800">
+                Aucune fiche trouvée pour ce thème.
+              </p>
+            ) : (
+              <StudyList fiches={fiches} storageKey={`rev-${slug}`} />
+            )}
+          </div>
+        </div>
+      </div>
     </main>
   );
 }
+
+/* ===== UI bits ===== */
+
+function BackHome() {
+  return (
+    <Link
+      href="/"
+      className="inline-flex items-center gap-1.5 rounded-full ring-1 ring-inset ring-black/5 px-2.5 py-1.5 text-sm text-zinc-600 hover:bg-zinc-100"
+      aria-label="Retour à l’accueil"
+    >
+      <svg
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        className="h-4 w-4"
+        aria-hidden="true"
+      >
+        <path d="M12.78 15.53a.75.75 0 01-1.06 0l-5-5a.75.75 0 010-1.06l5-5a.75.75 0 111.06 1.06L8.31 9.25h7.44a.75.75 0 010 1.5H8.31l4.47 4.47a.75.75 0 010 1.06z" />
+      </svg>
+      Accueil
+    </Link>
+  );
+}
+
+const THEMES = [
+  { slug: "interieur", label: "Intérieur" },
+  { slug: "exterieur", label: "Extérieur" },
+  { slug: "securite", label: "Sécurité routière" },
+  { slug: "secours", label: "Premiers secours" },
+];
+
+/** Switcher desktop : pastilles PLEINE couleur du thème.
+ *  Active = opacité 100 + anneau.
+ *  Inactive = opacité 80 (toujours la même couleur).
+ */
+function ThemeSwitcherDesktop({ current, colors }) {
+  return (
+    <nav
+      className="hidden sm:flex items-center gap-2"
+      aria-label="Changer de thème"
+    >
+      {THEMES.map((t) => {
+        const active = current === t.slug;
+        const c = colors[t.slug];
+        return (
+          <Link
+            key={t.slug}
+            href={`/theme/${t.slug}`}
+            aria-current={active ? "page" : undefined}
+            style={{ ["--c"]: c }}
+            className={[
+              "rounded-full px-3 py-1.5 text-xs font-medium text-white transition",
+              "[background:var(--c)]",
+              active
+                ? "opacity-100 ring-2 ring-offset-1 ring-[var(--c)]"
+                : "opacity-80 hover:opacity-90",
+            ].join(" ")}
+          >
+            {t.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+/** Menu mobile : liste avec point coloré du thème + liens */
+function ThemeSwitcherMobile({ current, colors }) {
+  return (
+    <details className="relative sm:hidden">
+      <summary className="list-none select-none rounded-full px-3 py-1.5 text-xs font-medium ring-1 ring-inset ring-zinc-300 text-zinc-700 bg-white hover:bg-zinc-100 cursor-pointer">
+        Changer de thème
+      </summary>
+
+      <ul
+        className="
+          absolute left-0 top-full mt-2
+          w-64 max-w-[calc(100vw-2rem)]
+          rounded-2xl bg-white ring-1 ring-black/5 shadow-lg p-2 space-y-1 z-30
+        "
+      >
+        {THEMES.map((t) => {
+          const active = current === t.slug;
+          return (
+            <li key={t.slug}>
+              <Link
+                href={`/theme/${t.slug}`}
+                className={[
+                  "flex items-center gap-2 rounded-lg px-3 py-2 text-sm",
+                  active
+                    ? "bg-zinc-900 text-white"
+                    : "text-zinc-700 hover:bg-zinc-100",
+                ].join(" ")}
+              >
+                <span
+                  className="h-2.5 w-2.5 rounded-full"
+                  style={{ backgroundColor: colors[t.slug] }}
+                />
+                {t.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </details>
+  );
+}
+
+/** Carte : barre d’accent pleine couleur du thème (via var --c posée sur la feuille) */
+function CardItem({ index, question, reponse }) {
+  return (
+    <li className="group relative overflow-hidden rounded-2xl bg-white ring-1 ring-black/5 shadow-[0_1px_0_rgba(0,0,0,0.03)] before:absolute before:inset-y-0 before:left-0 before:w-1.5 before:[background:var(--c)]">
+      <details className="p-3 sm:p-4">
+        <summary className="flex items-start gap-3 cursor-pointer list-none">
+          <span className="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-zinc-100 text-[11px] font-semibold text-zinc-700 ring-1 ring-inset ring-black/5">
+            {index}
+          </span>
+          <h3 className="text-base sm:text-[17px] font-semibold leading-tight text-zinc-900 tracking-tight">
+            {question}
+          </h3>
+        </summary>
+        <p className="mt-2 ml-9 text-[13px] leading-relaxed text-zinc-700 whitespace-pre-line">
+          {reponse}
+        </p>
+      </details>
+    </li>
+  );
+}
+

--- a/src/components/HomeResume.jsx
+++ b/src/components/HomeResume.jsx
@@ -1,0 +1,32 @@
+"use client";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function HomeResume({ autoRedirect = false }) {
+  const [slug, setSlug] = useState(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    try {
+      const s = localStorage.getItem("last-theme");
+      if (s) {
+        setSlug(s);
+        if (autoRedirect) router.replace(`/theme/${s}`);
+      }
+    } catch {}
+  }, [autoRedirect, router]);
+
+  if (!slug || autoRedirect) return null;
+
+  return (
+    <div className="mt-6 flex justify-center">
+      <Link
+        href={`/theme/${slug}`}
+        className="inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold text-white [background:#1f4f82] hover:opacity-90"
+      >
+        Continuer là où j’en étais
+      </Link>
+    </div>
+  );
+}

--- a/src/components/LastVisitedWriter.jsx
+++ b/src/components/LastVisitedWriter.jsx
@@ -1,0 +1,11 @@
+"use client";
+import { useEffect } from "react";
+
+export default function LastVisitedWriter({ slug }) {
+  useEffect(() => {
+    try {
+      localStorage.setItem("last-theme", slug);
+    } catch {}
+  }, [slug]);
+  return null;
+}

--- a/src/components/StudyList.jsx
+++ b/src/components/StudyList.jsx
@@ -1,0 +1,260 @@
+"use client";
+import { useEffect, useMemo, useState } from "react";
+
+function useLocalStorage(key, initialValue) {
+  const [state, setState] = useState(() => {
+    if (typeof window === "undefined") return initialValue;
+    try {
+      const raw = localStorage.getItem(key);
+      return raw != null ? JSON.parse(raw) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(state));
+    } catch {}
+  }, [key, state]);
+
+  return [state, setState];
+}
+
+
+export default function StudyList({ fiches, storageKey }) {
+  const [statusById, setStatusById] = useLocalStorage(storageKey, {});
+  const [revealAll, setRevealAll] = useState(false);
+  const [filter, setFilter] = useState("all");
+  const [shuffle, setShuffle] = useState(false);
+
+  const counts = useMemo(() => {
+    let known = 0,
+      doubt = 0,
+      unknown = 0,
+      seen = 0;
+    for (const id of Object.keys(statusById)) {
+      seen++;
+      if (statusById[id] === "known") known++;
+      else if (statusById[id] === "doubt") doubt++;
+      else if (statusById[id] === "unknown") unknown++;
+    }
+    return { known, doubt, unknown, seen, total: fiches.length };
+  }, [statusById, fiches.length]);
+
+  const filtered = useMemo(() => {
+    let arr = [...fiches];
+    if (filter === "review") {
+      arr = arr.filter((f) => ["doubt", "unknown"].includes(statusById[f.id]));
+    } else if (filter === "unseen") {
+      arr = arr.filter((f) => !statusById[f.id]);
+    } else if (filter === "known") {
+      arr = arr.filter((f) => statusById[f.id] === "known");
+    }
+    if (shuffle) {
+      for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+      }
+    }
+    return arr;
+  }, [fiches, filter, shuffle, statusById]);
+
+  function setStatus(id, s) {
+    setStatusById((prev) => ({ ...prev, [id]: s }));
+  }
+  function resetProgress() {
+    setStatusById({});
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-1">
+        <div className="flex items-center gap-2">
+          <FilterChip
+            active={filter === "all"}
+            onClick={() => setFilter("all")}
+            label={`Toutes (${counts.total})`}
+          />
+          <FilterChip
+            active={filter === "review"}
+            onClick={() => setFilter("review")}
+            label={`À revoir (${counts.doubt + counts.unknown})`}
+          />
+          <FilterChip
+            active={filter === "unseen"}
+            onClick={() => setFilter("unseen")}
+            label={`Non vues (${counts.total - counts.seen})`}
+          />
+          <FilterChip
+            active={filter === "known"}
+            onClick={() => setFilter("known")}
+            label={`Su (es) (${counts.known})`}
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <label className="inline-flex items-center gap-2 text-xs text-zinc-700">
+            <input
+              type="checkbox"
+              className="h-4 w-4 rounded border-zinc-300"
+              checked={shuffle}
+              onChange={(e) => setShuffle(e.target.checked)}
+            />
+            Mélanger
+          </label>
+          <label className="inline-flex items-center gap-2 text-xs text-zinc-700">
+            <input
+              type="checkbox"
+              className="h-4 w-4 rounded border-zinc-300"
+              checked={revealAll}
+              onChange={(e) => setRevealAll(e.target.checked)}
+            />
+            Tout afficher
+          </label>
+          <button
+            onClick={resetProgress}
+            className="rounded-full px-3 py-1.5 text-xs font-medium ring-1 ring-inset ring-zinc-300 text-zinc-700 hover:bg-zinc-100"
+          >
+            Réinitialiser
+          </button>
+        </div>
+      </div>
+
+      <ul className="grid gap-3 sm:gap-4 md:grid-cols-2">
+        {filtered.map((fiche, i) => (
+          <StudyCard
+            key={fiche.id}
+            index={i + 1}
+            fiche={fiche}
+            revealAll={revealAll}
+            status={statusById[fiche.id] || null}
+            onStatus={(s) => setStatus(fiche.id, s)}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function FilterChip({ active, onClick, label }) {
+  return (
+    <button
+      onClick={onClick}
+      className={[
+        "rounded-full px-3 py-1.5 text-xs font-medium transition",
+        active
+          ? "text-white [background:var(--c)]"
+          : "ring-1 ring-inset ring-zinc-300 text-zinc-700 hover:bg-zinc-100",
+      ].join(" ")}
+    >
+      {label}
+    </button>
+  );
+}
+
+function StudyCard({ index, fiche, revealAll, status, onStatus }) {
+  const [revealed, setRevealed] = useState(revealAll);
+  useEffect(() => {
+    setRevealed(revealAll);
+  }, [revealAll]);
+
+  const statusLabel =
+    status === "known"
+      ? "Su (e)"
+      : status === "doubt"
+      ? "J’hésitais"
+      : status === "unknown"
+      ? "Je ne savais pas"
+      : "Non vue";
+
+  return (
+    <li className="group relative overflow-hidden rounded-2xl bg-white ring-1 ring-black/5 shadow-[0_1px_0_rgba(0,0,0,0.03)] hover:shadow-md hover:-translate-y-[1px] transition before:absolute before:inset-y-0 before:left-0 before:w-1.5 before:[background:var(--c)]">
+      <div className="p-3 sm:p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-start gap-3 min-w-0">
+            <span className="mt-0.5 inline-flex h-6 w-6 shrink-0 select-none items-center justify-center rounded-full bg-zinc-100 text-[11px] font-semibold text-zinc-700 ring-1 ring-inset ring-black/5">
+              {index}
+            </span>
+            <div className="min-w-0">
+              <h3 className="text-base sm:text-[17px] font-semibold leading-tight text-zinc-900 tracking-tight">
+                {fiche.question}
+              </h3>
+              <div className="mt-1 text-[11px] text-zinc-500">
+                {revealed
+                  ? "Réponse affichée"
+                  : "Cliquer pour afficher la réponse"}
+                <span className="mx-1">•</span>
+                <span
+                  className={[
+                    "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ring-1 ring-inset",
+                    status === "known"
+                      ? "text-emerald-700 ring-emerald-200 bg-emerald-50"
+                      : status === "doubt"
+                      ? "text-amber-700 ring-amber-200 bg-amber-50"
+                      : status === "unknown"
+                      ? "text-red-700 ring-red-200 bg-red-50"
+                      : "text-zinc-700 ring-zinc-200 bg-zinc-50",
+                  ].join(" ")}
+                >
+                  {statusLabel}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <button
+            onClick={() => setRevealed((v) => !v)}
+            className="shrink-0 rounded-full px-3 py-1.5 text-xs font-medium text-white [background:var(--c)] hover:opacity-90"
+            aria-expanded={revealed}
+          >
+            {revealed ? "Masquer" : "Afficher"}
+          </button>
+        </div>
+
+        {revealed && (
+          <p className="mt-3 ml-9 text-[13px] leading-relaxed text-zinc-700 whitespace-pre-line">
+            {fiche.reponse}
+          </p>
+        )}
+
+        <div className="mt-3 ml-9 flex flex-wrap gap-2">
+          <EvalButton
+            active={status === "known"}
+            onClick={() => onStatus("known")}
+            label="Je savais (1)"
+            ring="ring-emerald-300"
+          />
+          <EvalButton
+            active={status === "doubt"}
+            onClick={() => onStatus("doubt")}
+            label="J’hésitais (2)"
+            ring="ring-amber-300"
+          />
+          <EvalButton
+            active={status === "unknown"}
+            onClick={() => onStatus("unknown")}
+            label="Je ne savais pas (3)"
+            ring="ring-red-300"
+          />
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function EvalButton({ active, onClick, label, ring }) {
+  return (
+    <button
+      onClick={onClick}
+      className={[
+        "rounded-full px-3 py-1.5 text-[12px] font-medium ring-2",
+        active
+          ? "[background:var(--c)] text-white"
+          : `ring-inset ${ring} text-zinc-700 hover:bg-zinc-100`,
+      ].join(" ")}
+    >
+      {label}
+    </button>
+  );
+}


### PR DESCRIPTION
### Ajouts
- StudyList : révélation de la réponse + auto-évaluation (Je savais / J’hésitais / Je ne savais pas)
- Filtres : Toutes / À revoir / Non vues / Su(es)
- Option de mélange des cartes
- Persistance par thème via localStorage (`rev-<slug>`)
- Mémorisation du dernier thème visité + bouton “Continuer là où j’en étais” sur la Home

### Correctifs
- Initialisation du hook `useLocalStorage` pour éviter le reset au premier rendu

### Chores
- Suppression de l’affichage “Recherche par mots clé” sur la Home
